### PR TITLE
fix: Update the Jira project key

### DIFF
--- a/.github/.jira_sync_config.yaml
+++ b/.github/.jira_sync_config.yaml
@@ -1,6 +1,6 @@
 settings:
     # Jira project key to create the issue in
-  jira_project_key: "KF"
+  jira_project_key: "SOLENG"
 
   # Dictionary mapping GitHub issue status to Jira issue status
   status_mapping:


### PR DESCRIPTION
Right now the Project key was set to `KF` while we should update it to `SOLENG` to ensure epics are created in 
https://warthogs.atlassian.net/browse/SOLENG-762