### PR TITLE
fix: use the check.yaml workflow on on_push

### DIFF
--- a/.github/workflows/on_push.yaml
+++ b/.github/workflows/on_push.yaml
@@ -17,7 +17,7 @@ jobs:
 
   tests:
     name: Run Tests
-    uses: ./.github/workflows/integrate.yaml
+    uses: ./.github/workflows/check.yaml
     secrets: inherit
 
   # publish runs in series with tests, and only publishes if tests passes


### PR DESCRIPTION
Follow-up from https://github.com/canonical/velero-operator/pull/40

The workflow was using the non-existent `integrate.yaml`, while in this repo we have `check.yaml`