### PR TITLE
docs: change charm title in `charmcraft.yaml`

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -3,7 +3,7 @@
 
 name: velero-operator
 type: charm
-title: Velero Operator Charm
+title: Velero Operator
 
 summary: Server Charm for backing up and restoring Kubernetes cluster resources using Velero.
 


### PR DESCRIPTION
Changes the charm title from `Velero Operator Charm` to `Velero Operator` as a product