### PR TITLE
feat: `default-volumes-to-fs-backup` charm config

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -45,6 +45,12 @@ config:
         The Velero AWS plugin container image to deploy
       default: "velero/velero-plugin-for-aws:v1.10.0"
       type: string
+    default-volumes-to-fs-backup:
+      description: |
+        Controls whether to backup all volumes using the file system backup method
+        (requires the node agent to be deployed)
+      default: false
+      type: boolean
 
 actions:
   run-cli:

--- a/src/charm.py
+++ b/src/charm.py
@@ -254,6 +254,10 @@ class VeleroOperatorCharm(TypedCharmBase[CharmConfig]):
                 self.lightkube_client, self.config.velero_image
             )
 
+        self.velero.update_velero_deployment_flags(
+            self.lightkube_client, self.config.default_volumes_to_fs_backup
+        )
+
     # HELPER METHODS
 
     def _log_and_set_status(

--- a/src/config.py
+++ b/src/config.py
@@ -13,6 +13,7 @@ class CharmConfig(BaseConfigModel):
     velero_image: str
     velero_aws_plugin_image: str
     use_node_agent: bool
+    default_volumes_to_fs_backup: bool
 
     @field_validator("*", mode="before")
     @classmethod

--- a/src/velero/core.py
+++ b/src/velero/core.py
@@ -5,7 +5,7 @@
 
 import logging
 import subprocess
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Union
 
 from lightkube import Client, codecs
 from lightkube.core.exceptions import ApiError, LoadResourceError
@@ -497,6 +497,76 @@ class Velero:
             )
         except ApiError as ae:
             raise VeleroError("Failed to remove Velero NodeAgent") from ae
+
+    def update_velero_deployment_flags(
+        self, kube_client: Client, default_volumes_to_fs_backup: bool
+    ) -> None:
+        """Update the Velero Deployment flags.
+
+        Args:
+            kube_client (Client): The lightkube client used to interact with the cluster.
+            default_volumes_to_fs_backup (bool): The new value for the default-volumes-to-fs-backup
+
+        Raises:
+            VeleroError: If the update fails.
+        """
+        flags: Dict[str, Union[str, bool]] = {
+            "default-volumes-to-fs-backup": default_volumes_to_fs_backup,
+        }
+        try:
+            deployment = kube_client.get(
+                Deployment, VELERO_DEPLOYMENT_NAME, namespace=self._namespace
+            )
+            if (
+                not deployment.spec
+                or not deployment.spec.template
+                or not deployment.spec.template.spec
+            ):
+                raise VeleroError("Velero Deployment has no valid spec")
+
+            container = next(
+                (
+                    c
+                    for c in deployment.spec.template.spec.containers
+                    if c.name == VELERO_DEPLOYMENT_NAME
+                ),
+                None,
+            )
+            if not container or not container.args:
+                raise VeleroError("Failed to get Velero Deployment container arguments")
+
+            new_args = [
+                arg
+                for arg in container.args
+                if not any(arg.startswith(f"--{flag}=") for flag in flags.keys())
+            ]
+            new_args += [f"--{flag}={str(value).lower()}" for flag, value in flags.items()]
+
+            new_deployment_spec = {
+                "spec": {
+                    "template": {
+                        "spec": {
+                            "containers": [
+                                {
+                                    "name": VELERO_DEPLOYMENT_NAME,
+                                    "args": new_args,
+                                }
+                            ]
+                        }
+                    },
+                    "strategy": {"type": "Recreate", "rollingUpdate": None},
+                }
+            }
+            kube_client.patch(
+                Deployment,
+                VELERO_DEPLOYMENT_NAME,
+                new_deployment_spec,
+                namespace=self._namespace,
+            )
+        except ApiError as ae:
+            if ae.status.code != 404:
+                logger.error("Failed to update Velero Deployment arguments: %s", ae)
+                raise VeleroError("Failed to update Velero Deployment arguments") from ae
 
     def update_velero_node_agent_image(self, kube_client: Client, new_image: str) -> None:
         """Update the Velero NodeAgent image.

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -22,7 +22,9 @@ logger = logging.getLogger(__name__)
 MICROCEPH_BUCKET = "testbucket"
 MICROCEPH_RGW_PORT = 7480
 K8S_TEST_NAMESPACE = "velero-integration-tests"
-K8S_TEST_RESOURCES_YAML_PATH = "./tests/integration/resources/test_resources.yaml"
+K8S_TEST_RESOURCES_YAML_PATH = "./tests/integration/resources/test_resources.yaml.j2"
+K8S_TEST_PVC_RESOURCE_NAME = "test-pvc"
+K8S_TEST_PVC_FILE_PATH = "test-file"
 
 
 @dataclasses.dataclass(frozen=True)
@@ -172,6 +174,8 @@ def k8s_test_resources(lightkube_client: Client):
     test_resources = {
         "namespace": namespace,
         "resources": [],
+        "test_file_path": K8S_TEST_PVC_FILE_PATH,
+        "pvc_name": K8S_TEST_PVC_RESOURCE_NAME,
     }
 
     try:
@@ -184,7 +188,13 @@ def k8s_test_resources(lightkube_client: Client):
             raise
 
     with open(K8S_TEST_RESOURCES_YAML_PATH) as f:
-        for obj in codecs.load_all_yaml(f):
+        for obj in codecs.load_all_yaml(
+            f,
+            context={
+                "pvc_name": K8S_TEST_PVC_RESOURCE_NAME,
+                "test_file": K8S_TEST_PVC_FILE_PATH,
+            },
+        ):
             if obj.metadata and not obj.metadata.namespace:
                 obj.metadata.namespace = K8S_TEST_NAMESPACE
             try:

--- a/tests/integration/resources/test_resources.yaml.j2
+++ b/tests/integration/resources/test_resources.yaml.j2
@@ -4,13 +4,14 @@ items:
 - apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
-    name: dummy-pvc
+    name: {{ pvc_name }}
   spec:
     accessModes:
       - ReadWriteOnce
     resources:
       requests:
-        storage: 50Mi
+        storage: 100Mi
+
 - apiVersion: apps/v1
   kind: Deployment
   metadata:
@@ -24,16 +25,19 @@ items:
       metadata:
         labels:
           app: dummy
+          pvc: {{ pvc_name }}
       spec:
         containers:
         - name: dummy-container
-          image: nginx
-          ports:
-          - containerPort: 80
+          image: busybox
+          command:
+          - sh
+          - -c
+          - "date +\"%Y-%m-%d %H:%M:%S\" >> /test-data/{{ test_file }} && sleep 3600"
           volumeMounts:
           - name: dummy-volume
             mountPath: /test-data
         volumes:
         - name: dummy-volume
           persistentVolumeClaim:
-            claimName: dummy-pvc
+            claimName: {{ pvc_name }}


### PR DESCRIPTION
The PR introduces the new charm config `default-volumes-to-fs-backup`, which allows backup/restore of Persistent Volume Claims when the cluster is deployed outside a cloud provider such as AWS or Azure. 

The config allows for the integration test that checks if backup/restore works regarding the CSI storage

Closes: #38