### PR TITLE
fix: Remove hardcoded path of multi-charm repos in release.yaml

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,9 +10,6 @@ on:
       origin-channel:
         description: 'Origin Channel'
         required: true
-      charm-name:
-        description: 'Charm subdirectory name'
-        required: true
 
 jobs:
   promote-charm:
@@ -28,4 +25,4 @@ jobs:
           destination-channel: ${{ github.event.inputs.destination-channel }}
           origin-channel: ${{ github.event.inputs.origin-channel }}
           tag-prefix: ${{ github.event.inputs.charm-name }}
-          charm-path: charms/${{ github.event.inputs.charm-name}}
+          charm-path: .


### PR DESCRIPTION
Right now the `release.yaml` workflow had hardcoded the input path to start with `charms/`. This was most probably a copy-paste issue.