### PR TITLE
Selective restore filters

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -143,6 +143,26 @@ actions:
         examples:
         - "none"
         - "update"
+      include-namespaces:
+        type: string
+        description: "Comma-separated namespaces to include in the restore."
+      exclude-namespaces:
+        type: string
+        description: "Comma-separated namespaces to exclude from the restore."
+      include-resources:
+        type: string
+        description: "Comma-separated Kubernetes resources to include."
+      exclude-resources:
+        type: string
+        description: "Comma-separated Kubernetes resources to exclude."
+      selector:
+        type: string
+        description: |
+          "Kubernetes label selectors (e.g. `key1=val1,key2=val2`) to filter objects to restore."
+      or-selector:
+        type: string
+        description: |
+          "OR label selectors (e.g. `key1=val1 or key2=val2 or key3=val3`) to filter objects to restore."
     required:
     - backup-uid
     additionalProperties: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ ignore-words-list = "NotIn"
 # LSPs and formatters
 [tool.pyright]
 include = ["src"]
-extraPaths = ["lib"]
+extraPaths = ["lib", "src"]
 exclude = ["src/libs/*"]
 
 [tool.black]

--- a/src/charm.py
+++ b/src/charm.py
@@ -39,7 +39,7 @@ from libs.azure_service_principal import AzureServicePrincipalRequirer
 from velero import (
     AzureStorageProvider,
     BackupInfo,
-    ExistingResourcePolicy,
+    RestoreParams,
     S3StorageProvider,
     StorageProviderError,
     Velero,
@@ -323,10 +323,12 @@ class VeleroOperatorCharm(TypedCharmBase[CharmConfig]):
 
     def on_restore_action(self, event: ops.ActionEvent) -> None:
         """Handle the restore action event."""
-        backup_uid = event.params["backup-uid"]
-        existing_resource_policy = ExistingResourcePolicy(
-            event.params.get("existing-resource-policy", "none")
-        )
+        try:
+            restore_params = RestoreParams.model_validate(event.params)
+        except ValidationError as ve:
+            event.fail(f"Invalid parameters: {ve}")
+            return
+
         check_message = (
             "You may check for more information using "
             "`run-cli command='restore describe {restore_name}'` "
@@ -343,8 +345,7 @@ class VeleroOperatorCharm(TypedCharmBase[CharmConfig]):
         try:
             restore_name = self.velero.create_restore(
                 self.lightkube_client,
-                backup_uid,
-                existing_resource_policy,
+                restore_params,
                 annotations={
                     "created-at": str(round(time.time())),
                 },

--- a/src/velero/__init__.py
+++ b/src/velero/__init__.py
@@ -3,17 +3,7 @@
 
 """Velero module."""
 
-from .core import (
-    BackupInfo,
-    ScheduleInfo,
-    Velero,
-    VeleroBackupStatusError,
-    VeleroCLIError,
-    VeleroError,
-    VeleroRestoreStatusError,
-    VeleroScheduleStatusError,
-    VeleroStatusError,
-)
+from .core import Velero
 from .crds import ExistingResourcePolicy
 from .providers import (
     AzureStorageConfig,
@@ -22,21 +12,33 @@ from .providers import (
     S3StorageProvider,
     StorageProviderError,
 )
+from .utils import (
+    BackupInfo,
+    RestoreParams,
+    ScheduleInfo,
+    VeleroBackupStatusError,
+    VeleroCLIError,
+    VeleroError,
+    VeleroRestoreStatusError,
+    VeleroScheduleStatusError,
+    VeleroStatusError,
+)
 
 __all__ = [
     "Velero",
     "VeleroError",
+    "VeleroBackupStatusError",
+    "VeleroRestoreStatusError",
+    "VeleroScheduleStatusError",
+    "VeleroCLIError",
+    "VeleroStatusError",
     "S3StorageProvider",
     "AzureStorageProvider",
     "StorageProviderError",
     "AzureStorageConfig",
     "S3StorageConfig",
-    "VeleroCLIError",
-    "VeleroStatusError",
     "ExistingResourcePolicy",
     "BackupInfo",
     "ScheduleInfo",
-    "VeleroBackupStatusError",
-    "VeleroRestoreStatusError",
-    "VeleroScheduleStatusError",
+    "RestoreParams",
 ]

--- a/src/velero/core.py
+++ b/src/velero/core.py
@@ -5,7 +5,6 @@
 
 import logging
 import subprocess
-from dataclasses import dataclass
 from typing import Any, Dict, List, Mapping, Optional, Union
 
 from charms.velero_libs.v0.velero_backup_config import VeleroBackupSpec
@@ -53,82 +52,24 @@ from k8s_utils import (
 from .crds import (
     Backup,
     BackupSpecModel,
-    ExistingResourcePolicy,
     Restore,
     RestoreSpecModel,
     Schedule,
     ScheduleSpecModel,
 )
 from .providers import VeleroStorageProvider
+from .utils import (
+    BackupInfo,
+    RestoreParams,
+    ScheduleInfo,
+    VeleroBackupStatusError,
+    VeleroCLIError,
+    VeleroError,
+    VeleroRestoreStatusError,
+    VeleroStatusError,
+)
 
 logger = logging.getLogger(__name__)
-
-
-@dataclass
-class BackupInfo:
-    """Data class to hold backup information."""
-
-    uid: str
-    name: str
-    labels: Dict[str, str]
-    annotations: Dict[str, str]
-    phase: str
-    start_timestamp: str
-    completion_timestamp: Optional[str] = None
-
-
-@dataclass
-class ScheduleInfo:
-    """Data class to hold schedule information."""
-
-    name: str
-    schedule: str
-    phase: str
-    labels: Dict[str, str]
-    paused: bool = False
-    last_backup: Optional[str] = None
-
-
-class VeleroError(Exception):
-    """Base class for Velero exceptions."""
-
-
-class VeleroStatusError(VeleroError):
-    """Exception raised for Velero status errors."""
-
-
-class VeleroBackupStatusError(VeleroStatusError):
-    """Exception raised for Velero backup status errors."""
-
-    def __init__(self, name: str, reason: str) -> None:
-        """Initialize the VeleroBackupStatusError with a name and reason."""
-        super().__init__(f"Velero backup '{name}' failed: {reason}")
-        self.name = name
-        self.reason = reason
-
-
-class VeleroRestoreStatusError(VeleroStatusError):
-    """Exception raised for Velero restore status errors."""
-
-    def __init__(self, name: str, reason: str) -> None:
-        """Initialize the VeleroRestoreStatusError with a name and reason."""
-        super().__init__(f"Velero restore '{name}' failed: {reason}")
-        self.name = name
-        self.reason = reason
-
-
-class VeleroScheduleStatusError(VeleroStatusError):
-    """Exception raised for Velero schedule status errors."""
-
-    def __init__(self, name: str, reason: str) -> None:
-        """Initialize the VeleroScheduleStatusError with a name and reason."""
-        super().__init__(f"Velero schedule '{name}' failed: {reason}")
-        self.name = name
-        self.reason = reason
-
-
-class VeleroCLIError(VeleroError):
-    """Exception raised for Velero CLI errors."""
 
 
 class ScheduleMixin:
@@ -1136,8 +1077,7 @@ class Velero(ScheduleMixin):
     def create_restore(
         self,
         kube_client: Client,
-        backup_uid: str,
-        existing_resource_policy: ExistingResourcePolicy = ExistingResourcePolicy.No,
+        restore_params: RestoreParams,
         labels: Optional[Dict[str, str]] = None,
         annotations: Optional[Dict[str, str]] = None,
     ) -> str:
@@ -1145,10 +1085,7 @@ class Velero(ScheduleMixin):
 
         Args:
             kube_client (Client): The lightkube client used to interact with the cluster.
-            backup_uid (str): The UID of the backup to restore from.
-                Will be used to generate the restore name.
-            existing_resource_policy (ExistingResourcePolicy, optional):
-                Policy for existing resources. Defaults to ExistingResourcePolicy.No ("none").
+            restore_params (VeleroRestoreParams): The restore parameters containing the details.
             labels (Optional[Dict[str, str]], optional):
                 Additional labels to apply to the restore resource.
             annotations (Optional[Dict[str, str]], optional):
@@ -1162,15 +1099,15 @@ class Velero(ScheduleMixin):
             VeleroError: If the restore creation fails.
             VeleroRestoreStatusError: If the restore status is not successful.
         """
-        logger.info("Checking if Velero Backup with UID '%s' exists", backup_uid)
+        logger.info("Checking if Velero Backup with UID '%s' exists", restore_params.backup_uid)
         backup_name = k8s_get_backup_name_by_uid(
             kube_client,
-            backup_uid,
+            restore_params.backup_uid,
             self._namespace,
         )
 
         if not backup_name:
-            raise VeleroError(f"Velero Backup with UID '{backup_uid}' not found")
+            raise VeleroError(f"Velero Backup with UID '{restore_params.backup_uid}' not found")
 
         restore = Restore(
             metadata=ObjectMeta(
@@ -1181,7 +1118,19 @@ class Velero(ScheduleMixin):
             ),
             spec=RestoreSpecModel(
                 backupName=backup_name,
-                existingResourcePolicy=existing_resource_policy,
+                existingResourcePolicy=restore_params.existing_resource_policy,
+                includedNamespaces=restore_params.include_namespaces,
+                includedResources=restore_params.include_resources,
+                excludedNamespaces=restore_params.exclude_namespaces,
+                excludedResources=restore_params.exclude_resources,
+                labelSelector=(
+                    {"matchLabels": restore_params.selector} if restore_params.selector else None
+                ),
+                orLabelSelectors=(
+                    [{"matchLabels": {k: v}} for k, v in restore_params.or_selector.items()]
+                    if restore_params.or_selector
+                    else None
+                ),
             ),
         )
 

--- a/src/velero/crds/restore.py
+++ b/src/velero/crds/restore.py
@@ -33,7 +33,17 @@ class RestoreSpecModel(DictMixin):
     excludedNamespaces: Optional[List[str]] = None
     includedResources: Optional[List[str]] = None
     excludedResources: Optional[List[str]] = None
+
+    # Kubernetes label selector to restrict which resources are included in the restore.
+    # Only equality-based matching is supported via matchLabels — a resource must match
+    # all specified labels to be included. Cannot be used together with orLabelSelectors.
+    # Example: {"matchLabels": {"app": "myapp", "env": "prod"}}
     labelSelector: Optional[Dict[str, Dict[str, str]]] = None
+    # Alternative to labelSelector: a list of label selectors where a resource is
+    # included if it satisfies at least one selector (logical OR across the list).
+    # Each selector uses matchLabels (equality-based only). Cannot be used together
+    # with labelSelector.
+    # Example: [{"matchLabels": {"app": "myapp"}}, {"matchLabels": {"env": "prod"}}]
     orLabelSelectors: Optional[List[Dict[str, Dict[str, str]]]] = None
 
 

--- a/src/velero/crds/restore.py
+++ b/src/velero/crds/restore.py
@@ -7,7 +7,7 @@ Reference: https://velero.io/docs/v1.16/api-types/restore
 """
 
 from enum import Enum
-from typing import ClassVar, List, Optional
+from typing import ClassVar, Dict, List, Optional
 
 from lightkube.codecs import resource_registry
 from lightkube.core import resource as res
@@ -29,6 +29,12 @@ class RestoreSpecModel(DictMixin):
     backupName: str
     restorePVs: Optional[bool] = None
     existingResourcePolicy: Optional[ExistingResourcePolicy] = None
+    includedNamespaces: Optional[List[str]] = None
+    excludedNamespaces: Optional[List[str]] = None
+    includedResources: Optional[List[str]] = None
+    excludedResources: Optional[List[str]] = None
+    labelSelector: Optional[Dict[str, Dict[str, str]]] = None
+    orLabelSelectors: Optional[List[Dict[str, Dict[str, str]]]] = None
 
 
 @dataclass

--- a/src/velero/utils.py
+++ b/src/velero/utils.py
@@ -1,0 +1,195 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Velero utilities."""
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from velero.crds.restore import ExistingResourcePolicy
+
+LABEL_COMPONENT_INVALID_CHARS = r"[^a-zA-Z0-9\-_\./]"
+
+
+@dataclass
+class BackupInfo:
+    """Data class to hold backup information."""
+
+    uid: str
+    name: str
+    labels: Dict[str, str]
+    annotations: Dict[str, str]
+    phase: str
+    start_timestamp: str
+    completion_timestamp: Optional[str] = None
+
+
+@dataclass
+class ScheduleInfo:
+    """Data class to hold schedule information."""
+
+    name: str
+    schedule: str
+    phase: str
+    labels: Dict[str, str]
+    paused: bool = False
+    last_backup: Optional[str] = None
+
+
+class VeleroError(Exception):
+    """Base class for Velero exceptions."""
+
+
+class VeleroStatusError(VeleroError):
+    """Exception raised for Velero status errors."""
+
+
+class VeleroBackupStatusError(VeleroStatusError):
+    """Exception raised for Velero backup status errors."""
+
+    def __init__(self, name: str, reason: str) -> None:
+        """Initialize the VeleroBackupStatusError with a name and reason."""
+        super().__init__(f"Velero backup '{name}' failed: {reason}")
+        self.name = name
+        self.reason = reason
+
+
+class VeleroRestoreStatusError(VeleroStatusError):
+    """Exception raised for Velero restore status errors."""
+
+    def __init__(self, name: str, reason: str) -> None:
+        """Initialize the VeleroRestoreStatusError with a name and reason."""
+        super().__init__(f"Velero restore '{name}' failed: {reason}")
+        self.name = name
+        self.reason = reason
+
+
+class VeleroScheduleStatusError(VeleroStatusError):
+    """Exception raised for Velero schedule status errors."""
+
+    def __init__(self, name: str, reason: str) -> None:
+        """Initialize the VeleroScheduleStatusError with a name and reason."""
+        super().__init__(f"Velero schedule '{name}' failed: {reason}")
+        self.name = name
+        self.reason = reason
+
+
+class VeleroCLIError(VeleroError):
+    """Exception raised for Velero CLI errors."""
+
+
+class RestoreParams(BaseModel):
+    """Structured parameters for the restore action."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    backup_uid: str = Field(validation_alias="backup-uid")
+    existing_resource_policy: ExistingResourcePolicy = Field(
+        validation_alias="existing-resource-policy", default=ExistingResourcePolicy.No
+    )
+    include_namespaces: List[str] | None = Field(
+        validation_alias="include-namespaces", default=None
+    )
+    exclude_namespaces: List[str] | None = Field(
+        validation_alias="exclude-namespaces", default=None
+    )
+    include_resources: List[str] | None = Field(validation_alias="include-resources", default=None)
+    exclude_resources: List[str] | None = Field(validation_alias="exclude-resources", default=None)
+    selector: Optional[Dict[str, str]] | None = Field(validation_alias="selector", default=None)
+    or_selector: Optional[Dict[str, str]] | None = Field(
+        validation_alias="or-selector", default=None
+    )
+
+    @classmethod
+    def _check_component(cls, value: str) -> None:
+        """Check if the value contains invalid characters."""
+        import re
+
+        if not value.strip():
+            raise ValueError("Value cannot be empty or whitespace")
+        if re.search(LABEL_COMPONENT_INVALID_CHARS, value):
+            raise ValueError(f"Value '{value}' contains invalid characters")
+
+    @field_validator("backup_uid", mode="before")
+    @classmethod
+    def validate_backup_uid(cls, v):
+        """Ensure backup_uid is not empty after stripping whitespace."""
+        if not v.strip():
+            raise ValueError("backup-uid must not be empty")
+        return v
+
+    @model_validator(mode="after")
+    def check_pairs(self):
+        """Ensure that selector and or_selector are not both set."""
+        if self.selector is not None and self.or_selector is not None:
+            raise ValueError("Cannot specify both 'selector' and 'or-selector' parameters")
+
+        if self.include_namespaces is not None and self.exclude_namespaces is not None:
+            raise ValueError(
+                "Cannot specify both 'include-namespaces' and 'exclude-namespaces' parameters"
+            )
+
+        if self.include_resources is not None and self.exclude_resources is not None:
+            raise ValueError(
+                "Cannot specify both 'include-resources' and 'exclude-resources' parameters"
+            )
+
+        return self
+
+    @field_validator(
+        "include_namespaces",
+        "exclude_namespaces",
+        "include_resources",
+        "exclude_resources",
+        mode="before",
+    )
+    @classmethod
+    def split_comma_separated(cls, v):
+        """Split comma-separated strings into lists."""
+        if isinstance(v, str):
+            return [item.strip() for item in v.split(",") if item.strip()]
+        return v
+
+    @classmethod
+    def _parse_selector(
+        cls,
+        value,
+        field_name: str,
+        separator: str,
+    ):
+        """Parse selector-like values as key=value pairs."""
+        items = [item.strip() for item in value.split(separator) if item.strip()]
+        if not items:
+            raise ValueError(
+                f"Invalid {field_name} format: '{value}' "
+                f"(expected key=value pairs separated by '{separator.strip()}')"
+            )
+
+        parsed = {}
+
+        for item in items:
+            if "=" not in item:
+                raise ValueError(f"Invalid {field_name} format: '{item}' (expected key=value)")
+
+            key, item_value = item.split("=", 1)
+            cls._check_component(key)
+            cls._check_component(item_value)
+            key = key.strip()
+            item_value = item_value.strip()
+            parsed[key] = item_value
+
+        return parsed or None
+
+    @field_validator("selector", mode="before")
+    @classmethod
+    def parse_selector(cls, v):
+        """Parse the selector string into a dictionary."""
+        return cls._parse_selector(v, field_name="selector", separator=",")
+
+    @field_validator("or_selector", mode="before")
+    @classmethod
+    def parse_or_selector(cls, v):
+        """Parse the or-selector string into a list of dictionaries."""
+        return cls._parse_selector(v, field_name="or-selector", separator=" or ")

--- a/tests/integration/resources/test_resources.yaml.j2
+++ b/tests/integration/resources/test_resources.yaml.j2
@@ -70,3 +70,18 @@ items:
       - protocol: TCP
         port: 80
         targetPort: 8080
+
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: dummy-service-2
+    labels:
+        app: dummy-2
+  spec:
+      type: ClusterIP
+      selector:
+      app: dummy-2
+      ports:
+      - protocol: TCP
+        port: 80
+        targetPort: 8080

--- a/tests/integration/test_backup_relation.py
+++ b/tests/integration/test_backup_relation.py
@@ -23,12 +23,13 @@ from helpers import (
     is_relation_broken,
     is_relation_joined,
     k8s_assert_resource_exists,
+    k8s_assert_resource_not_exists,
     k8s_delete_and_wait,
     k8s_get_velero_backup,
     run_charm_action,
     verify_pvc_content,
 )
-from lightkube.resources.core_v1 import Namespace
+from lightkube.resources.core_v1 import ConfigMap, Namespace, Service
 from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
@@ -298,6 +299,153 @@ async def test_create_restore(ops_test: OpsTest, k8s_test_resources, lightkube_c
             lightkube_client, type(resource), name=resource.metadata.name, namespace=test_namespace
         )
     verify_pvc_content(lightkube_client, test_namespace, test_pvc_name, test_file, 2)
+
+
+@pytest.mark.abort_on_fail
+async def test_create_selective_restore(ops_test: OpsTest, k8s_test_resources, lightkube_client):
+    """Test creating a restore with selectors.
+
+    The second backup contains ConfigMap (app=dummy-2) and Service dummy-service (app=dummy).
+    Using selector 'app=dummy-2' should restore only the ConfigMap, not the Service.
+    """
+    logger.info("Testing create-restore action with selectors")
+    model = get_model(ops_test)
+    unit = model.applications[APP_NAME].units[0]
+    test_namespace = k8s_test_resources["namespace"].metadata.name
+    k8s_delete_and_wait(lightkube_client, Namespace, test_namespace, grace_period=0)
+
+    logger.info("Getting current backups")
+    result = await run_charm_action(unit, "list-backups", app=TEST_APP_NAME)
+    assert len(result["backups"]) > 0, "No backups found"
+    logger.info("Backups found: %s", result["backups"])
+
+    backup_uid = next(
+        (
+            uid
+            for uid, backup in result["backups"].items()
+            if backup.get("endpoint") == TEST_APP_SECOND_RELATION_NAME
+        ),
+        None,
+    )
+    assert backup_uid is not None, "No backup found for second endpoint"
+
+    logger.info("Creating a restore with label selector")
+    await run_charm_action(
+        unit,
+        "restore",
+        **{
+            "backup-uid": backup_uid,
+            "exclude-resources": "services",
+            "selector": "app=dummy-2",
+        },
+    )
+
+    logger.info("Verifying the restore")
+    # we expect only the ConfigMap with dummy-config name to be restored
+    k8s_assert_resource_exists(
+        lightkube_client, ConfigMap, name="dummy-config", namespace=test_namespace
+    )
+    k8s_assert_resource_not_exists(
+        lightkube_client, Service, name="dummy-service", namespace=test_namespace
+    )
+
+
+@pytest.mark.abort_on_fail
+async def test_create_or_selector_restore(ops_test: OpsTest, k8s_test_resources, lightkube_client):
+    """Test creating a restore filtered by or-selector.
+
+    The second backup contains ConfigMap (app=dummy-2), Service dummy-service (app=dummy),
+    and Service dummy-service-2 (app=dummy-2). Using or-selector 'app=dummy-2' should restore
+    only resources labelled app=dummy-2: ConfigMap + Service (dummy-service-2).
+    """
+    logger.info("Testing create-restore action with or-selector")
+    model = get_model(ops_test)
+    unit = model.applications[APP_NAME].units[0]
+    test_namespace = k8s_test_resources["namespace"].metadata.name
+    k8s_delete_and_wait(lightkube_client, Namespace, test_namespace, grace_period=0)
+
+    result = await run_charm_action(unit, "list-backups", app=TEST_APP_NAME)
+    backup_uid = next(
+        (
+            uid
+            for uid, backup in result["backups"].items()
+            if backup.get("endpoint") == TEST_APP_SECOND_RELATION_NAME
+        ),
+        None,
+    )
+    assert backup_uid is not None, "No backup found for second endpoint"
+
+    logger.info("Creating a restore with or-selector 'app=dummy-2'")
+    await run_charm_action(
+        unit,
+        "restore",
+        **{
+            "backup-uid": backup_uid,
+            "or-selector": "app=dummy-2",
+        },
+    )
+
+    logger.info(
+        "Verifying the restore: dummy-config and dummy-service-2 expected; dummy-service not"
+    )
+    k8s_assert_resource_exists(
+        lightkube_client, ConfigMap, name="dummy-config", namespace=test_namespace
+    )
+    k8s_assert_resource_exists(
+        lightkube_client, Service, name="dummy-service-2", namespace=test_namespace
+    )
+    k8s_assert_resource_not_exists(
+        lightkube_client, Service, name="dummy-service", namespace=test_namespace
+    )
+
+
+@pytest.mark.abort_on_fail
+async def test_create_existing_resource_policy_restore(
+    ops_test: OpsTest, k8s_test_resources, lightkube_client
+):
+    """Test creating a restore with existing-resource-policy=update.
+
+    After the previous test the namespace contains only dummy-config (ConfigMap). Restoring
+    the full second backup with 'update' policy should successfully overwrite the ConfigMap and
+    create the missing Services, resulting in all three resources being present.
+    """
+    logger.info("Testing create-restore action with existing-resource-policy=update")
+    model = get_model(ops_test)
+    unit = model.applications[APP_NAME].units[0]
+    test_namespace = k8s_test_resources["namespace"].metadata.name
+    # Namespace already exists from the previous test with dummy-config present.
+
+    result = await run_charm_action(unit, "list-backups", app=TEST_APP_NAME)
+    backup_uid = next(
+        (
+            uid
+            for uid, backup in result["backups"].items()
+            if backup.get("endpoint") == TEST_APP_SECOND_RELATION_NAME
+        ),
+        None,
+    )
+    assert backup_uid is not None, "No backup found for second endpoint"
+
+    logger.info("Creating a restore with existing-resource-policy=update")
+    await run_charm_action(
+        unit,
+        "restore",
+        **{
+            "backup-uid": backup_uid,
+            "existing-resource-policy": "update",
+        },
+    )
+
+    logger.info("Verifying all resources from the second backup are present after update restore")
+    k8s_assert_resource_exists(
+        lightkube_client, ConfigMap, name="dummy-config", namespace=test_namespace
+    )
+    k8s_assert_resource_exists(
+        lightkube_client, Service, name="dummy-service", namespace=test_namespace
+    )
+    k8s_assert_resource_exists(
+        lightkube_client, Service, name="dummy-service-2", namespace=test_namespace
+    )
 
 
 @pytest.mark.abort_on_fail

--- a/tests/integration/test_schedule.py
+++ b/tests/integration/test_schedule.py
@@ -337,7 +337,7 @@ async def test_schedule_cleanup_on_relation_broken(ops_test: OpsTest, lightkube_
             )
             assert len(schedules) == 1, f"Expected 1 schedule, found {len(schedules)}"
 
-    logger.info(f"Schedule exists: {schedules[0]['metadata']['name']}")
+    logger.info(f"Schedule exists: {schedules[0]['metadata']['name']}")  # type: ignore
 
     # Remove the relation
     logger.info(f"Removing relation with {TEST_APP_FIRST_RELATION_NAME}")

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -7,7 +7,6 @@ import httpx
 import pytest
 from lightkube.core.exceptions import ApiError
 from ops import testing
-from scenario import Relation
 
 from charm import VeleroOperatorCharm
 from constants import StorageRelation
@@ -299,11 +298,11 @@ def test_on_remove(mock_velero, mock_lightkube_client):
 @pytest.mark.parametrize(
     "relations",
     [
-        [Relation(endpoint=StorageRelation.S3.value)],
-        [Relation(endpoint=StorageRelation.AZURE.value)],
+        [testing.Relation(endpoint=StorageRelation.S3.value)],
+        [testing.Relation(endpoint=StorageRelation.AZURE.value)],
         [
-            Relation(endpoint=StorageRelation.S3.value),
-            Relation(endpoint=StorageRelation.AZURE.value),
+            testing.Relation(endpoint=StorageRelation.S3.value),
+            testing.Relation(endpoint=StorageRelation.AZURE.value),
         ],
     ],
 )
@@ -355,7 +354,7 @@ def test_storage_relation_changed_success(
     # Arrange
     mock_velero.is_storage_configured.return_value = False
     ctx = testing.Context(VeleroOperatorCharm)
-    relation = Relation(endpoint=storage_relation.value, remote_app_data=relation_data)
+    relation = testing.Relation(endpoint=storage_relation.value, remote_app_data=relation_data)
 
     # Act
     state_out = ctx.run(
@@ -394,7 +393,7 @@ def test_storage_relation_changed_invalid_config(
     # Arrange
     mock_velero.is_storage_configured.return_value = False
     ctx = testing.Context(VeleroOperatorCharm)
-    relation = Relation(endpoint=storage_relation.value, remote_app_data=relation_data)
+    relation = testing.Relation(endpoint=storage_relation.value, remote_app_data=relation_data)
 
     # Act
     state_out = ctx.run(
@@ -412,8 +411,8 @@ def test_storage_relation_changed_many_relations(mock_velero, mock_lightkube_cli
     # Arrange
     mock_velero.is_storage_configured.return_value = False
     ctx = testing.Context(VeleroOperatorCharm)
-    s3_relation = Relation(endpoint=StorageRelation.S3.value)
-    azure_relation = Relation(endpoint=StorageRelation.AZURE.value)
+    s3_relation = testing.Relation(endpoint=StorageRelation.S3.value)
+    azure_relation = testing.Relation(endpoint=StorageRelation.AZURE.value)
 
     # Act
     state_out = ctx.run(
@@ -438,7 +437,7 @@ def test_storage_relation_changed_configure(
     # Arrange
     mock_velero.is_storage_configured.return_value = provider_configured
     ctx = testing.Context(VeleroOperatorCharm)
-    relation = Relation(
+    relation = testing.Relation(
         endpoint=StorageRelation.S3.value,
         remote_app_data={
             "region": "us-east-1",
@@ -472,7 +471,7 @@ def test_storage_relation_changed_install_error(mock_velero, mock_lightkube_clie
         "Failed to add Velero backup location"
     )
     ctx = testing.Context(VeleroOperatorCharm)
-    relation = Relation(
+    relation = testing.Relation(
         endpoint=StorageRelation.S3.value,
         remote_app_data={
             "bucket": "test-bucket",
@@ -498,7 +497,7 @@ def test_storage_relation_broken_success(mock_velero, mock_lightkube_client):
     """Test that the relation_broken event removes the storage provider."""
     # Arrange
     ctx = testing.Context(VeleroOperatorCharm)
-    relation = Relation(endpoint=StorageRelation.S3.value)
+    relation = testing.Relation(endpoint=StorageRelation.S3.value)
 
     # Act
     state_out = ctx.run(
@@ -515,7 +514,7 @@ def test_storage_relation_broken_error(mock_velero, mock_lightkube_client):
     """Test that the relation_departed event raises an error if remove fails."""
     # Arrange
     ctx = testing.Context(VeleroOperatorCharm)
-    relation = Relation(endpoint=StorageRelation.S3.value)
+    relation = testing.Relation(endpoint=StorageRelation.S3.value)
     mock_velero.remove_storage_locations.side_effect = VeleroError(
         "Failed to remove storage locations"
     )
@@ -633,7 +632,7 @@ def test_on_config_changed_success(
     """Test that the config_changed event is handled correctly."""
     # Arrange
     ctx = testing.Context(VeleroOperatorCharm)
-    relations = [Relation(endpoint=relation.value)] if relation else []
+    relations = [testing.Relation(endpoint=relation.value)] if relation else []
 
     # Act
     ctx.run(
@@ -745,7 +744,7 @@ def test_run_create_backup_action_success(
         mock_storage_rel.return_value = StorageRelation.S3
         mock_velero.is_storage_configured.return_value = True
         ctx = testing.Context(VeleroOperatorCharm)
-        relation = Relation(
+        relation = testing.Relation(
             endpoint=VELERO_BACKUP_ENDPOINT,
             remote_app_name="test-app",
             remote_app_data={
@@ -774,7 +773,7 @@ def test_run_create_backup_action_success(
         (
             "test-app:test-endpoint",
             "test-model",
-            Relation(
+            testing.Relation(
                 endpoint=VELERO_BACKUP_ENDPOINT,
                 remote_app_name="test-app",
                 remote_app_data={
@@ -810,7 +809,7 @@ def test_run_create_backup_action_success(
         (
             "test-app:test-endpoint",
             "test-model",
-            Relation(
+            testing.Relation(
                 endpoint=VELERO_BACKUP_ENDPOINT,
                 remote_app_name="test-app",
                 remote_app_data={
@@ -827,7 +826,7 @@ def test_run_create_backup_action_success(
         (
             "test-app:test-endpoint",
             "test-model",
-            Relation(
+            testing.Relation(
                 endpoint=VELERO_BACKUP_ENDPOINT,
                 remote_app_name="test-app",
                 remote_app_data={
@@ -845,7 +844,7 @@ def test_run_create_backup_action_success(
         (
             "test-app:test-endpoint",
             "test-model",
-            Relation(
+            testing.Relation(
                 endpoint=VELERO_BACKUP_ENDPOINT,
                 remote_app_name="test-app",
                 remote_app_data={
@@ -920,6 +919,8 @@ def test_run_restore_action_success(
 @pytest.mark.parametrize(
     "backup_uid,storage_configured,restore_side_effect",
     [
+        # Invalid parameters (empty backup UID)
+        ("", True, None),
         # Storage not configured
         ("test-backup-uid", False, None),
         # Restore fails (VeleroError)
@@ -1101,7 +1102,7 @@ def test_reconcile_schedules_creates_schedule(mock_velero, mock_lightkube_client
         mock_velero.is_storage_configured.return_value = True
         mock_velero.is_installed.return_value = True
         ctx = testing.Context(VeleroOperatorCharm)
-        relation = Relation(
+        relation = testing.Relation(
             endpoint=VELERO_BACKUP_ENDPOINT,
             remote_app_name="test-app",
             remote_app_data={
@@ -1141,7 +1142,7 @@ def test_reconcile_schedules_deletes_schedule_when_no_schedule_in_spec(
         mock_velero.is_storage_configured.return_value = True
         mock_velero.is_installed.return_value = True
         ctx = testing.Context(VeleroOperatorCharm)
-        relation = Relation(
+        relation = testing.Relation(
             endpoint=VELERO_BACKUP_ENDPOINT,
             remote_app_name="test-app",
             remote_app_data={
@@ -1178,7 +1179,7 @@ def test_reconcile_schedules_handles_create_error(mock_velero, mock_lightkube_cl
         mock_velero.is_installed.return_value = True
         mock_velero.create_or_update_schedule.side_effect = VeleroError("Schedule creation failed")
         ctx = testing.Context(VeleroOperatorCharm)
-        relation = Relation(
+        relation = testing.Relation(
             endpoint=VELERO_BACKUP_ENDPOINT,
             remote_app_name="test-app",
             remote_app_data={
@@ -1213,7 +1214,7 @@ def test_reconcile_schedules_handles_delete_error(mock_velero, mock_lightkube_cl
         mock_velero.is_installed.return_value = True
         mock_velero.delete_schedule_by_labels.side_effect = VeleroError("Schedule deletion failed")
         ctx = testing.Context(VeleroOperatorCharm)
-        relation = Relation(
+        relation = testing.Relation(
             endpoint=VELERO_BACKUP_ENDPOINT,
             remote_app_name="test-app",
             remote_app_data={
@@ -1247,7 +1248,7 @@ def test_reconcile_schedules_skips_invalid_spec(mock_velero, mock_lightkube_clie
         mock_velero.is_storage_configured.return_value = True
         mock_velero.is_installed.return_value = True
         ctx = testing.Context(VeleroOperatorCharm)
-        relation = Relation(
+        relation = testing.Relation(
             endpoint=VELERO_BACKUP_ENDPOINT,
             remote_app_name="test-app",
             remote_app_data={
@@ -1283,7 +1284,7 @@ def test_reconcile_schedules_skips_missing_app_or_endpoint(mock_velero, mock_lig
         mock_velero.is_storage_configured.return_value = True
         mock_velero.is_installed.return_value = True
         ctx = testing.Context(VeleroOperatorCharm)
-        relation = Relation(
+        relation = testing.Relation(
             endpoint=VELERO_BACKUP_ENDPOINT,
             remote_app_name="test-app",
             remote_app_data={
@@ -1350,7 +1351,7 @@ def test_relation_broken_cleans_up_schedule(mock_velero, mock_lightkube_client):
         mock_velero.is_storage_configured.return_value = True
         mock_velero.is_installed.return_value = True
         ctx = testing.Context(VeleroOperatorCharm)
-        relation = Relation(
+        relation = testing.Relation(
             endpoint=VELERO_BACKUP_ENDPOINT,
             remote_app_name="test-app",
             remote_app_data={
@@ -1390,7 +1391,7 @@ def test_relation_broken_missing_app_name_or_endpoint(mock_velero, mock_lightkub
         mock_velero.is_storage_configured.return_value = True
         mock_velero.is_installed.return_value = True
         ctx = testing.Context(VeleroOperatorCharm)
-        relation = Relation(
+        relation = testing.Relation(
             endpoint=VELERO_BACKUP_ENDPOINT,
             remote_app_name="test-app",
             remote_app_data={
@@ -1424,7 +1425,7 @@ def test_relation_broken_delete_fails(mock_velero, mock_lightkube_client):
         mock_velero.is_installed.return_value = True
         mock_velero.delete_schedule_by_labels.side_effect = VeleroError("Delete failed")
         ctx = testing.Context(VeleroOperatorCharm)
-        relation = Relation(
+        relation = testing.Relation(
             endpoint=VELERO_BACKUP_ENDPOINT,
             remote_app_name="test-app",
             remote_app_data={

--- a/tests/unit/velero/test_core.py
+++ b/tests/unit/velero/test_core.py
@@ -26,6 +26,7 @@ from constants import (
 )
 from k8s_utils import K8sResource
 from velero import (
+    RestoreParams,
     Velero,
     VeleroBackupStatusError,
     VeleroError,
@@ -178,7 +179,7 @@ def test_check_velero_deployment_success(mock_lightkube_client):
     mock_deployment.status.conditions = [MagicMock(type="Available", status="True")]
     mock_lightkube_client.get.return_value = mock_deployment
 
-    assert Velero.check_velero_deployment(mock_lightkube_client, "velero", False) is None
+    assert Velero.check_velero_deployment(mock_lightkube_client, "velero") is None
 
 
 def test_check_velero_deployment_unavailable(mock_lightkube_client):
@@ -1263,8 +1264,7 @@ def test_create_restore_success(mock_check, mock_lightkube_client, velero):
 
     velero.create_restore(
         mock_lightkube_client,
-        backup_uid,
-        "none",
+        RestoreParams(backup_uid=backup_uid),
         {"app": "app", "endpoint": "endpoint"},
         None,
     )
@@ -1283,6 +1283,83 @@ def test_create_restore_success(mock_check, mock_lightkube_client, velero):
     assert spec.existingResourcePolicy == "none"
 
 
+@patch.object(Velero, "check_velero_restore")
+def test_create_restore_selectors_success_1(mock_check, mock_lightkube_client, velero):
+    """Check create_restore generates a correct Restore CR with selectors provided."""
+    backup_uid = "test-backup-uid"
+    backup_name = "test-backup"
+
+    backup_1 = MagicMock()
+    backup_1.metadata = ObjectMeta(uid="another-backup-uid", name="another-backup")
+    backup_2 = MagicMock()
+    backup_2.metadata = None
+    backup_3 = MagicMock()
+    backup_3.metadata = ObjectMeta(uid=backup_uid, name=backup_name)
+    mock_lightkube_client.list.return_value = [backup_1, backup_2, backup_3]
+
+    velero.create_restore(
+        mock_lightkube_client,
+        RestoreParams.model_validate(
+            {
+                "backup_uid": backup_uid,
+                "include_resources": "pods,services",
+                "exclude_namespaces": "kube-system,default",
+                "selector": "ns-label=value,res-label=value",
+            }
+        ),
+        {"app": "app", "endpoint": "endpoint"},
+        None,
+    )
+
+    args, kwargs = mock_lightkube_client.create.call_args
+    actual_restore = args[0]
+
+    spec = actual_restore.spec
+    assert spec.includedResources == ["pods", "services"]
+    assert spec.excludedNamespaces == ["kube-system", "default"]
+    assert spec.labelSelector == {"matchLabels": {"ns-label": "value", "res-label": "value"}}
+
+
+@patch.object(Velero, "check_velero_restore")
+def test_create_restore_selectors_success_2(mock_check, mock_lightkube_client, velero):
+    """Check create_restore generates a correct Restore CR with selectors provided."""
+    backup_uid = "test-backup-uid"
+    backup_name = "test-backup"
+
+    backup_1 = MagicMock()
+    backup_1.metadata = ObjectMeta(uid="another-backup-uid", name="another-backup")
+    backup_2 = MagicMock()
+    backup_2.metadata = None
+    backup_3 = MagicMock()
+    backup_3.metadata = ObjectMeta(uid=backup_uid, name=backup_name)
+    mock_lightkube_client.list.return_value = [backup_1, backup_2, backup_3]
+
+    velero.create_restore(
+        mock_lightkube_client,
+        RestoreParams.model_validate(
+            {
+                "backup_uid": backup_uid,
+                "exclude_resources": "pods,services",
+                "include_namespaces": "kube-system,default",
+                "or_selector": "ns-label=value or res-label=value",
+            }
+        ),
+        {"app": "app", "endpoint": "endpoint"},
+        None,
+    )
+
+    args, kwargs = mock_lightkube_client.create.call_args
+    actual_restore = args[0]
+
+    spec = actual_restore.spec
+    assert spec.excludedResources == ["pods", "services"]
+    assert spec.includedNamespaces == ["kube-system", "default"]
+    assert spec.orLabelSelectors == [
+        {"matchLabels": {"ns-label": "value"}},
+        {"matchLabels": {"res-label": "value"}},
+    ]
+
+
 def test_create_restore_get_api_error(mock_lightkube_client, velero):
     """Check create_restore raises a ApiError when the API call to get backup fails."""
     mock_response = MagicMock(spec=httpx.Response)
@@ -1291,7 +1368,9 @@ def test_create_restore_get_api_error(mock_lightkube_client, velero):
     mock_lightkube_client.list.side_effect = api_error
 
     with pytest.raises(ApiError):
-        velero.create_restore(mock_lightkube_client, "test-backup", "none", {}, {})
+        velero.create_restore(
+            mock_lightkube_client, RestoreParams(backup_uid="test-backup"), {}, {}
+        )
 
 
 @patch("velero.core.k8s_get_backup_name_by_uid", return_value="test-restore")
@@ -1303,7 +1382,7 @@ def test_create_restore_create_api_error(mock_lightkube_client, velero):
     mock_lightkube_client.create.side_effect = api_error
 
     with pytest.raises(VeleroError):
-        velero.create_restore(mock_lightkube_client, "test-restore", "test-backup", "none", {})
+        velero.create_restore(mock_lightkube_client, RestoreParams(backup_uid="test-backup"), {})
 
 
 def test_create_restore_missing_backup(mock_lightkube_client, velero):
@@ -1311,7 +1390,9 @@ def test_create_restore_missing_backup(mock_lightkube_client, velero):
     mock_lightkube_client.list.return_value = []
 
     with pytest.raises(VeleroError):
-        velero.create_restore(mock_lightkube_client, "test-backup", "none", {}, {})
+        velero.create_restore(
+            mock_lightkube_client, RestoreParams(backup_uid="test-backup"), {}, {}
+        )
 
 
 def test_check_velero_restore_success(mock_lightkube_client):

--- a/tests/unit/velero/test_core_schedule.py
+++ b/tests/unit/velero/test_core_schedule.py
@@ -56,9 +56,11 @@ def test_create_schedule_success(mock_lightkube_client, velero):
     mock_lightkube_client.create.assert_called_once()
     created_schedule = mock_lightkube_client.create.call_args[0][0]
     assert isinstance(created_schedule, Schedule)
+    assert created_schedule.metadata is not None
     assert created_schedule.metadata.generateName == "test-app-backup-"
     assert created_schedule.metadata.namespace == NAMESPACE
     assert created_schedule.metadata.labels == labels
+    assert created_schedule.spec is not None
     assert created_schedule.spec.schedule == "0 2 * * *"
 
 

--- a/tests/unit/velero/test_utils.py
+++ b/tests/unit/velero/test_utils.py
@@ -1,0 +1,137 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import pytest
+from pydantic import ValidationError
+
+from velero import ExistingResourcePolicy, RestoreParams
+
+valid_restore_params = [
+    pytest.param(
+        {"backup-uid": "backup.uid-1"},
+        {
+            "backup_uid": "backup.uid-1",
+            "existing_resource_policy": ExistingResourcePolicy.No,
+            "include_namespaces": None,
+            "exclude_namespaces": None,
+            "include_resources": None,
+            "exclude_resources": None,
+            "selector": None,
+            "or_selector": None,
+        },
+        id="minimal-required",
+    ),
+    pytest.param(
+        {
+            "backup-uid": "backup.uid-2",
+            "existing-resource-policy": "update",
+            "include-namespaces": "ns-a, ns-b",
+            "include-resources": "pods, services",
+            "selector": "app=my-app,tier=backend",
+        },
+        {
+            "backup_uid": "backup.uid-2",
+            "existing_resource_policy": ExistingResourcePolicy.Update,
+            "include_namespaces": ["ns-a", "ns-b"],
+            "exclude_namespaces": None,
+            "include_resources": ["pods", "services"],
+            "exclude_resources": None,
+            "selector": {"app": "my-app", "tier": "backend"},
+            "or_selector": None,
+        },
+        id="comma-separated-and-selector",
+    ),
+    pytest.param(
+        {
+            "backup-uid": "backup.uid-3",
+            "exclude-namespaces": ["kube-system"],
+            "exclude-resources": ["secrets"],
+            "or-selector": "env=prod or app=velero",
+        },
+        {
+            "backup_uid": "backup.uid-3",
+            "existing_resource_policy": ExistingResourcePolicy.No,
+            "include_namespaces": None,
+            "exclude_namespaces": ["kube-system"],
+            "include_resources": None,
+            "exclude_resources": ["secrets"],
+            "selector": None,
+            "or_selector": {"env": "prod", "app": "velero"},
+        },
+        id="list-values-and-or-selector",
+    ),
+]
+
+invalid_restore_params = [
+    pytest.param(
+        {
+            "backup-uid": "backup.uid-4",
+            "selector": "app=velero",
+            "or-selector": "env=prod",
+        },
+        id="selector-and-or-selector-mutually-exclusive",
+    ),
+    pytest.param(
+        {
+            "backup-uid": "backup.uid-5",
+            "include-namespaces": "team-a",
+            "exclude-namespaces": "team-b",
+        },
+        id="include-exclude-namespaces-mutually-exclusive",
+    ),
+    pytest.param(
+        {
+            "backup-uid": "backup.uid-6",
+            "include-resources": "pods",
+            "exclude-resources": "services",
+        },
+        id="include-exclude-resources-mutually-exclusive",
+    ),
+    pytest.param(
+        {"backup-uid": "backup.uid-7", "selector": "appvelero"},
+        id="selector-missing-equals",
+    ),
+    pytest.param(
+        {"backup-uid": "backup.uid-8", "selector": "app$=velero"},
+        id="selector-invalid-characters",
+    ),
+    pytest.param(
+        {"backup-uid": "backup.uid-9", "or-selector": "envprod"},
+        id="or-selector-missing-equals",
+    ),
+    pytest.param(
+        {"backup-uid": "backup.uid-10", "or-selector": "env=prod or app$=velero"},
+        id="or-selector-invalid-characters",
+    ),
+    pytest.param(
+        {"backup-uid": "backup.uid-11", "existing-resource-policy": "replace"},
+        id="invalid-existing-resource-policy",
+    ),
+    pytest.param(
+        {"selector": "app=velero"},
+        id="missing-required-backup-uid",
+    ),
+    pytest.param({"backup-uid": ""}, id="empty-backup-uid"),
+    pytest.param({"backup-uid": "   "}, id="whitespace-backup-uid"),
+    pytest.param({"backup-uid": "backup.uid-11", "selector": "app="}, id="selector-empty-value"),
+    pytest.param({"backup-uid": "backup.uid-11", "selector": "   "}, id="selector-empty-value"),
+]
+
+
+@pytest.mark.parametrize("params, expected", valid_restore_params)
+def test_restore_params_valid(params, expected):
+    """Test that valid restore parameters are accepted."""
+    try:
+        model = RestoreParams.model_validate(params)
+    except ValidationError as ve:
+        pytest.fail(f"Valid parameters failed validation: {ve}")
+
+    for key, value in expected.items():
+        assert getattr(model, key) == value
+
+
+@pytest.mark.parametrize("params", invalid_restore_params)
+def test_restore_params_invalid(params):
+    """Test that invalid restore parameters are rejected."""
+    with pytest.raises(ValidationError):
+        RestoreParams.model_validate(params)


### PR DESCRIPTION
The PR add "selective restore" filters to the Velero Operator charm’s `restore` action used to create backups requested by client charms, mirroring Velero CLI filtering flags. 

New action parameters:
- `include-namespaces`
- `exclude-namespaces`
- `include-resources`
- `exclude-resources`
- `selector`
- `or-selector`

Closes: #164