### PR TITLE
chore: align renovate config to other MLOps repos

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,6 @@
 {
-    "enabled": false
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": [
+        "github>canonical/charmed-kubeflow-workflows"
+    ]
 }


### PR DESCRIPTION
This PR updates the `renovate` config to extend the maintained one by MLOps team.
This might also finally disable dependabot PRs.