### PR TITLE
fix: merge CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,4 @@
 # These owners will be the default owners for everything in the repo. Unless a
 # later match takes precedence. Owners will be requested for
 # review when someone opens a pull request.
-*    @canonical/soleng-reviewers
-*    @canonical/mlops
+*    @canonical/soleng-reviewers @canonical/mlops


### PR DESCRIPTION
This PR fixes the `CODEOWNERS` file so that MLOps **and** SolEng are set as reviewers for the PRs.